### PR TITLE
#46 [FEAT] 손익 계산서 비교 지표 api 구현

### DIFF
--- a/src/main/java/com/hungry/consultorang/model/state/GetComparisionResponseModel.java
+++ b/src/main/java/com/hungry/consultorang/model/state/GetComparisionResponseModel.java
@@ -1,0 +1,17 @@
+package com.hungry.consultorang.model.state;
+
+import com.hungry.consultorang.model.ParentModel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+@Builder
+public class GetComparisionResponseModel extends ParentModel {
+    String updateDate;
+    SIHModel sameBusiness;
+    SIHModel sameSale;
+    SIHModel sameSize;
+    SIHModel userModel;
+}

--- a/src/main/java/com/hungry/consultorang/model/state/GetComparisonRequestModel.java
+++ b/src/main/java/com/hungry/consultorang/model/state/GetComparisonRequestModel.java
@@ -1,0 +1,12 @@
+package com.hungry.consultorang.model.state;
+
+import com.hungry.consultorang.model.ParentModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class GetComparisonRequestModel extends ParentModel {
+    int userId;
+    String ym;
+}

--- a/src/main/java/com/hungry/consultorang/model/state/SIHModel.java
+++ b/src/main/java/com/hungry/consultorang/model/state/SIHModel.java
@@ -1,0 +1,15 @@
+package com.hungry.consultorang.model.state;
+
+import com.hungry.consultorang.model.ParentModel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+@Builder
+public class SIHModel extends ParentModel {
+    long totalSale;
+    long foodCost;
+    long humanCost;
+}

--- a/src/main/java/com/hungry/consultorang/rest/state/StateController.java
+++ b/src/main/java/com/hungry/consultorang/rest/state/StateController.java
@@ -1,0 +1,42 @@
+package com.hungry.consultorang.rest.state;
+
+import com.hungry.consultorang.common.response.RestResponse;
+import com.hungry.consultorang.model.state.GetComparisionResponseModel;
+import com.hungry.consultorang.model.state.GetComparisonRequestModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping(value="/state")
+public class StateController {
+    StateService stateService;
+
+    public StateController(StateService stateService) {
+        this.stateService = stateService;
+    }
+
+    @PostMapping("/setAnual")
+    public ResponseEntity<RestResponse> setAnual() throws Exception{
+        RestResponse response = new RestResponse();
+
+        //stateService.setAnual();
+
+        return new ResponseEntity<RestResponse>(response.setSuccess(), HttpStatus.OK);
+
+    }
+
+    @PostMapping("/getComparison")
+    public ResponseEntity<RestResponse> getComparison(@RequestBody GetComparisonRequestModel param)
+        throws Exception{
+        RestResponse ret = new RestResponse();
+        GetComparisionResponseModel data = stateService.getComparison(param);
+
+        return new ResponseEntity<RestResponse>(ret.setSuccess(data), HttpStatus.OK);
+    }
+
+
+}

--- a/src/main/java/com/hungry/consultorang/rest/state/StateService.java
+++ b/src/main/java/com/hungry/consultorang/rest/state/StateService.java
@@ -1,0 +1,11 @@
+package com.hungry.consultorang.rest.state;
+
+import com.hungry.consultorang.model.state.GetComparisionResponseModel;
+import com.hungry.consultorang.model.state.GetComparisonRequestModel;
+
+public interface StateService {
+
+    void setAnual() throws Exception;
+    GetComparisionResponseModel getComparison(GetComparisonRequestModel param)
+        throws Exception;
+}

--- a/src/main/java/com/hungry/consultorang/rest/state/StateServiceImpl.java
+++ b/src/main/java/com/hungry/consultorang/rest/state/StateServiceImpl.java
@@ -1,0 +1,109 @@
+package com.hungry.consultorang.rest.state;
+
+import com.hungry.consultorang.common.dao.CommonDao;
+import com.hungry.consultorang.common.util.ExcelParserUtil;
+import com.hungry.consultorang.model.state.GetComparisionResponseModel;
+import com.hungry.consultorang.model.state.GetComparisonRequestModel;
+import com.hungry.consultorang.model.state.SIHModel;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.util.HashMap;
+
+@Service
+public class StateServiceImpl implements StateService{
+
+    CommonDao commonDao;
+
+    public StateServiceImpl(CommonDao commonDao) {
+        this.commonDao = commonDao;
+    }
+
+    @Override
+    public void setAnual() throws Exception{
+
+        ExcelParserUtil parserUtil = new ExcelParserUtil("C:/Users/USER/Desktop/test/anual.xlsx",1);
+
+        int idx = 2;
+        int size = parserUtil.getRowSize();
+        HashMap<String, Object> req = new HashMap<>();
+        for(;idx<size; idx++){
+            String[] types = parserUtil.getCellData(idx, 0).split("/");
+            req.put("stCd", types[0]);
+            req.put("ssCd", "null");
+            if(types.length>=2) req.put("ssCd", types[1]);
+            int totalSale = getInt(parserUtil.getCellData(idx, 1));
+            int foodCost = getInt(parserUtil.getCellData(idx,3));
+            int employeeCost = getInt(parserUtil.getCellData(idx,4));
+            int hireCost = getInt(parserUtil.getCellData(idx,5));
+            int taxCost = getInt(parserUtil.getCellData(idx,6));
+            int familyEmployeeCost = getInt(parserUtil.getCellData(idx,7));
+            int employerCost = getInt(parserUtil.getCellData(idx,8));
+            int etcCost = getInt(parserUtil.getCellData(idx,9));
+            int saleProfit = getInt(parserUtil.getCellData(idx,10));
+            req.put("totalSale", totalSale);req.put("foodCost", foodCost);
+            req.put("employeeCost", employeeCost); req.put("hireCost", hireCost);
+            req.put("taxCost", taxCost); req.put("familyEmployeeCost", familyEmployeeCost);
+            req.put("employerCost", employerCost); req.put("etcCost", etcCost);
+            req.put("saleProfit", saleProfit);
+            commonDao.batchInsert("state.insertPlCompareData", req);
+        }
+        commonDao.flushStatements();
+    }
+    private int getInt(String temp){
+        return (int) Double.parseDouble(temp);
+    }
+
+    @Override
+    public GetComparisionResponseModel getComparison(GetComparisonRequestModel param) throws Exception {
+        HashMap<String, Object> req = new HashMap<>();
+        req.put("userId", param.getUserId()); req.put("saleYm", param.getYm());
+        req.put("startYmd", param.getYm()+"00"); req.put("endYmd",param.getYm()+"99");
+        int totalSale = (int) commonDao.selectOne("account.getTotalSales", req);
+        int totalEtcSale = (int) commonDao.selectOne("account.getTotalEtcSales", req);
+        totalSale += totalEtcSale;
+        req.put("expendType", "ET001");
+        int totalIngre = (int) commonDao.selectOne("account.getTotalExpend", req);
+        req.put("expendType", "ET002");
+        int totalHuman = (int) commonDao.selectOne("account.getTotalExpend", req);
+
+        SIHModel user = SIHModel.builder()
+            .totalSale(totalSale)
+            .foodCost(totalIngre)
+            .humanCost(totalHuman).build();
+        HashMap<String, String> businessCd = (HashMap<String, String>) commonDao.selectOne("state.getBusinessCd", req);
+        businessCd.put("businessSale", generateSaleCd(totalSale));
+
+        req.clear();
+
+        req.put("stCd", businessCd.get("businessSize"));
+        SIHModel size = (SIHModel) commonDao.selectOne("state.getCompareData",req);
+        req.put("stCd", businessCd.get("businessType"));
+        req.put("ssCd", businessCd.get("businessIngre"));
+        SIHModel business = (SIHModel) commonDao.selectOne("state.getCompareData",req);
+        req.put("stCd", businessCd.get("businessSale"));
+        SIHModel sale = (SIHModel) commonDao.selectOne("state.getCompareData",req);
+
+
+        GetComparisionResponseModel ret = GetComparisionResponseModel.builder()
+            .sameBusiness(business)
+            .sameSale(sale)
+            .sameSize(size)
+            .userModel(user)
+            .updateDate("2020"+param.getYm().substring(4,6)).build();
+
+        return ret;
+    }
+
+    private String generateSaleCd(int totalSale){
+        if(totalSale < 416){
+            return "SS001";
+        }else if(totalSale < 832){
+            return "SS002";
+        }else if(totalSale < 4160){
+            return "SS003";
+        }else{
+            return "SS004";
+        }
+    }
+}

--- a/src/main/resources/mapper/account.xml
+++ b/src/main/resources/mapper/account.xml
@@ -248,12 +248,15 @@
 
     <select id="getTotalSales" resultType="int">
         SELECT
-            SUM(menu_cost * sale_quantity)
+            IFNULL(A.sale, 0) AS sale
+        FROM
+        (SELECT
+            SUM(menu_cost * sale_quantity) AS sale
         FROM
             SALES
         WHERE
             user_id = #{userId}
-            AND sale_ym = #{saleYm}
+            AND sale_ym = #{saleYm}) A
     </select>
 
     <select id="getTotalHistoryList" resultType="TotalHistoryModel">
@@ -395,18 +398,27 @@
 
     <select id="getTotalEtcSales" resultType="int">
         SELECT
-            SUM(menu_sale)
+            IFNULL(A.menu_sale,0)
+        FROM (SELECT
+            SUM(menu_sale) AS menu_sale
         FROM ETC_SALES
         WHERE user_id = #{userId}
-        AND sale_ymd BETWEEN #{startYmd} AND #{endYmd}
+        AND sale_ymd BETWEEN #{startYmd} AND #{endYmd}) A
     </select>
 
     <select id = "getTotalExpend" resultType="int">
         SELECT
-            SUM(expend_cost)
+            IFNULL(A.expend_cost, 0)
+        FROM
+        (SELECT
+            SUM(expend_cost) AS expend_cost
         FROM EXPEND
         WHERE user_id = #{userId}
         AND expend_ymd BETWEEN #{startYmd} AND #{endYmd}
+        <if test="expendType!=null and expendType!=''">
+            AND expend_type = #{expendType}
+        </if>
+        ) A
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/state.xml
+++ b/src/main/resources/mapper/state.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="state">
+
+    <insert id="insertPlCompareData">
+        <![CDATA[
+            INSERT INTO PL_COMPARE_TBL
+            (st_cd, ss_cd, total_sale, food_cost, employee_cost,
+             hire_cost, tax_cost, family_employee_cost, employer_cost,
+             etc_cost, sale_profit)
+            VALUES
+            (#{stCd}, #{ssCd}, #{totalSale}, #{foodCost}, #{employeeCost},
+             #{hireCost}, #{taxCost}, #{familyEmployeeCost}, #{employerCost},
+             #{etcCost}, #{saleProfit}
+            )
+        ]]>
+    </insert>
+
+    <select id="getBusinessCd" resultType="HashMap">
+        SELECT
+            business_type AS businessType,
+            business_ingre AS businessIngre,
+            business_size AS businessSize
+        FROM BUSINESS
+        WHERE user_id = #{userId}
+    </select>
+
+    <select id="getCompareData" resultType="SIHModel">
+        <![CDATA[
+            SELECT
+                total_sale*10000 AS total_sale,
+                food_cost*10000 AS food_cost,
+                (employee_cost + hire_cost + family_employee_cost+employer_cost)*10000 AS human_cost
+            FROM PL_COMPARE_TBL
+            WHERE 1=1
+            AND st_cd = #{stCd}
+        ]]>
+        <if test="stCd=='ST001'">
+            AND ss_cd = #{ssCd}
+        </if>
+    </select>
+
+</mapper>


### PR DESCRIPTION
# Description
* 사용자의 가게 타입, 규모, 매출액에 따라 동종에 해당되는 값(인건비, 재료비, 매출액) 가져오는 api
* 현재 데이터가 1년 단위기 때문에 해당 데이터에 12를 나눈 값을 가져옴
* 달마다 정확한 값을 가져올 수 있게 한다면 리팩토링 예정